### PR TITLE
Add missing equals() and hashcode() to OpenSearchDevServicesBuildTime…

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
+[![version](https://img.shields.io/maven-central/v/io.quarkiverse.opensearch/quarkus-opensearch-parent)](https://repo1.maven.org/maven2/io/quarkiverse/opensearch/)
 [![Build](https://github.com/quarkiverse/quarkus-opensearch/workflows/Build/badge.svg)](https://github.com/quarkiverse/quarkus-opensearch/actions?query=workflow%3ABuild)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 

--- a/opensearch-rest-client/deployment/src/main/java/io/quarkiverse/opensearch/restclient/lowlevel/deployment/OpenSearchDevServicesBuildTimeConfig.java
+++ b/opensearch-rest-client/deployment/src/main/java/io/quarkiverse/opensearch/restclient/lowlevel/deployment/OpenSearchDevServicesBuildTimeConfig.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.opensearch.restclient.lowlevel.deployment;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigItem;
@@ -65,4 +66,24 @@ public class OpenSearchDevServicesBuildTimeConfig {
      */
     @ConfigItem(defaultValue = "opensearch")
     public String serviceName;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        OpenSearchDevServicesBuildTimeConfig that = (OpenSearchDevServicesBuildTimeConfig) o;
+        return Objects.equals(shared, that.shared)
+            && Objects.equals(enabled, that.enabled)
+            && Objects.equals(port, that.port)
+            && Objects.equals(imageName, that.imageName)
+            && Objects.equals(javaOpts, that.javaOpts)
+            && Objects.equals(serviceName, that.serviceName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(enabled, port, imageName, javaOpts, shared, serviceName);
+    }
 }


### PR DESCRIPTION
…Config

DevServicesOpenSearchProcessor on line 76 compares existing config with new config to know if the devservice must be restarted, without equals() method this always return false.