### PR TITLE
Update current version to 3.2.3

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,3 +1,3 @@
 release:
-  current-version: "2.2.0"
+  current-version: "3.2.3"
   next-version: "999-SNAPSHOT"


### PR DESCRIPTION
- Add OpenSearch 3.x support
- Remove deprecated REST client dependencies from docs module
- Improve transport provider error messages and documentation
- Bump Quarkus 3.30.2 → 3.30.8

Extension version line pivots from 2.x (last 2.2.0) to 3.x on this branch to align with OpenSearch 3.x support.