### PR TITLE
Update current version to 3.4.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,3 +1,3 @@
 release:
-  current-version: "3.2.2"
+  current-version: "3.4.0"
   next-version: "999-SNAPSHOT"


### PR DESCRIPTION
Re-release after fixing release-prepare workflow to use JDK 21.

- Migrate from JDK 17 to JDK 21
- Bump Quarkus 3.30.2 → 3.34.3
- Bump OpenSearch and OpenSearch client 3.4.0 → 3.8.0
- Bump opensearch-testcontainers 3.0.2 → 4.1.0 (testcontainers core 2.x)
- Bump Apache HttpClient 5 to 5.6 with content decompression fix
- Bump Apache HttpCore 5 to 5.4.2
- Bump quarkus-amazon-services 3.12.1 → 3.16.0
- Bump quarkiverse-parent 20 → 21
- Bump jandex-maven-plugin 3.2.7 → 3.5.3
- Add transport options SPI and mTLS certificate reload support
- Add per-client health check configuration