### PR TITLE
Update current version to 3.3.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,3 +1,3 @@
 release:
-  current-version: "3.2.2"
+  current-version: "3.3.0"
   next-version: "999-SNAPSHOT"


### PR DESCRIPTION
Re-release after fixing release-prepare workflow to use JDK 21. Inaugural release for the Quarkus 3.33 LTS line.