### PR TITLE
fix(devservices): make processor loadable without testcontainers (closes #557)

### DIFF
--- a/opensearch-client-common/deployment/pom.xml
+++ b/opensearch-client-common/deployment/pom.xml
@@ -35,6 +35,14 @@
         <dependency>
             <groupId>org.opensearch</groupId>
             <artifactId>opensearch-testcontainers</artifactId>
+            <!-- Explicit version: ensures the resolved value lands in the
+                 published deployment-artifact pom rather than relying on
+                 downstream consumers to walk the parent chain for
+                 ${opensearch-testcontainers.version}. Without this,
+                 downstream Maven resolution can fall through to an older
+                 transitive version and the deployment processor fails to
+                 load OpenSearchContainer. See #557. -->
+            <version>${opensearch-testcontainers.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>junit</groupId>

--- a/opensearch-client-common/deployment/src/main/java/io/quarkiverse/opensearch/deployment/DevServicesOpenSearchProcessor.java
+++ b/opensearch-client-common/deployment/src/main/java/io/quarkiverse/opensearch/deployment/DevServicesOpenSearchProcessor.java
@@ -5,8 +5,6 @@ import java.util.*;
 import java.util.function.Supplier;
 
 import org.jboss.logging.Logger;
-import org.opensearch.testcontainers.OpenSearchContainer;
-import org.testcontainers.utility.DockerImageName;
 
 import io.quarkus.builder.BuildException;
 import io.quarkus.deployment.IsNormal;
@@ -156,26 +154,21 @@ public class DevServicesOpenSearchProcessor {
         Optional<ContainerAddress> maybeContainerAddress = openSearchContainerLocator.locateContainer(
                 config.serviceName(), config.shared(), launchMode.getLaunchMode());
 
-        Supplier<DevServicesResultBuildItem.RunningDevService> startContainer = () -> {
-            OpenSearchContainer container = new OpenSearchContainer(
-                    DockerImageName.parse(config.imageName())
-                            .asCompatibleSubstituteFor("opensearchproject/opensearch"));
-
-            if (config.serviceName() != null) {
-                container.withLabel(DEV_SERVICE_LABEL, config.serviceName());
-            }
-
-            config.port().ifPresent(port -> container.setPortBindings(List.of(port + ":" + port)));
-            timeout.ifPresent(container::withStartupTimeout);
-            container.addEnv("OPENSEARCH_JAVA_OPTS", config.javaOpts());
-
-            container.start();
-            return new DevServicesResultBuildItem.RunningDevService(
-                    OpenSearchDevServicesProcessor.FEATURE,
-                    container.getContainerId(),
-                    container::close,
-                    buildPropertiesMap(buildItemConfig, container.getHttpHostAddress()));
-        };
+        // Delegate the actual container creation to OpenSearchContainerStarter.
+        // Routing through the helper class keeps OpenSearchContainer out of
+        // this class's bytecode, so the processor itself loads even when
+        // org.opensearch:opensearch-testcontainers isn't on the deployment
+        // classpath (the helper is loaded lazily on first call). Closes
+        // https://github.com/quarkiverse/quarkus-opensearch/issues/557.
+        Supplier<DevServicesResultBuildItem.RunningDevService> startContainer = () -> OpenSearchContainerStarter.start(
+                config.imageName(),
+                OpenSearchDevServicesProcessor.FEATURE,
+                DEV_SERVICE_LABEL,
+                Optional.ofNullable(config.serviceName()),
+                config.port(),
+                timeout,
+                config.javaOpts(),
+                buildItemConfig.hostsConfigProperties);
 
         return maybeContainerAddress
                 .map(addr -> new DevServicesResultBuildItem.RunningDevService(

--- a/opensearch-client-common/deployment/src/main/java/io/quarkiverse/opensearch/deployment/OpenSearchContainerStarter.java
+++ b/opensearch-client-common/deployment/src/main/java/io/quarkiverse/opensearch/deployment/OpenSearchContainerStarter.java
@@ -1,0 +1,70 @@
+package io.quarkiverse.opensearch.deployment;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.opensearch.testcontainers.OpenSearchContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
+
+/**
+ * Lazily-loaded helper that creates and starts an {@link OpenSearchContainer}.
+ *
+ * <p>
+ * This class is the <strong>only</strong> place in the deployment module
+ * that references the OpenSearch testcontainers types. It is invoked from a
+ * {@code Supplier} inside {@link DevServicesOpenSearchProcessor}'s build
+ * step, so its bytecode is loaded only when Dev Services actually run
+ * (dev/test mode) — not when the deployment classpath is scanned at build
+ * time. Without this split, the JVM eagerly verifies the lambda's
+ * synthetic method on processor-class load, requiring
+ * {@code org.opensearch:opensearch-testcontainers} on the classpath even
+ * for production builds where Dev Services aren't used.
+ *
+ * <p>
+ * See <a href="https://github.com/quarkiverse/quarkus-opensearch/issues/557">issue #557</a>.
+ */
+final class OpenSearchContainerStarter {
+
+    private OpenSearchContainerStarter() {
+    }
+
+    static DevServicesResultBuildItem.RunningDevService start(
+            String imageName,
+            String featureName,
+            String containerLabel,
+            Optional<String> serviceName,
+            Optional<Integer> port,
+            Optional<Duration> startupTimeout,
+            String javaOpts,
+            Set<String> hostsConfigProperties) {
+
+        OpenSearchContainer container = new OpenSearchContainer(
+                DockerImageName.parse(imageName)
+                        .asCompatibleSubstituteFor("opensearchproject/opensearch"));
+
+        serviceName.ifPresent(name -> container.withLabel(containerLabel, name));
+        port.ifPresent(p -> container.setPortBindings(List.of(p + ":" + p)));
+        startupTimeout.ifPresent(container::withStartupTimeout);
+        container.addEnv("OPENSEARCH_JAVA_OPTS", javaOpts);
+
+        container.start();
+
+        Map<String, String> propertiesToSet = new HashMap<>();
+        String strippedHost = container.getHttpHostAddress().replaceFirst("^http://", "");
+        for (String property : hostsConfigProperties) {
+            propertiesToSet.put(property, strippedHost);
+        }
+
+        return new DevServicesResultBuildItem.RunningDevService(
+                featureName,
+                container.getContainerId(),
+                container::close,
+                propertiesToSet);
+    }
+}


### PR DESCRIPTION
## What

Closes #557.

Two related fixes so the deployment processor loads cleanly even when `org.opensearch:opensearch-testcontainers` is missing from the consumer's deployment classpath:

1. **`DevServicesOpenSearchProcessor`** — drop the top-level `OpenSearchContainer` / `DockerImageName` imports and delegate the container-creating lambda body to a new package-private helper, **`OpenSearchContainerStarter`**. The processor's bytecode no longer references the testcontainers types, so the JVM verifier can load the class without `OpenSearchContainer` on the classpath. The helper is class-loaded lazily on first call (only in dev/test mode where Dev Services run).

2. **`opensearch-client-common/deployment/pom.xml`** — add an explicit `<version>${opensearch-testcontainers.version}</version>` on the testcontainers dep so the resolved version lands in the published deployment artifact's `.pom`. Without this, downstream consumers don't always walk the parent chain to resolve the property and fall through to a stale transitive version.

## Why

A Quarkus 3.33.1 application that depends on `quarkus-opensearch-java-client` 3.3.0 fails the `quarkus:build` goal on otherwise normal production builds, even with Dev Services disabled, because the deployment-processor scan can't load `DevServicesOpenSearchProcessor` without `OpenSearchContainer` on the classpath. Issue #557 has the full repro and analysis.

## Test plan

- [x] `mvn -pl opensearch-client-common/deployment -am compile -DskipTests` is clean
- [ ] (CI / reviewer) extension-side tests still pass
- [ ] (CI / reviewer) downstream Quarkus 3.33 app builds without an explicit `opensearch-testcontainers` consumer-side dep

## Targets

This PR targets **`3.33-LTS`** (the maintenance branch tracking Quarkus 3.33). A follow-up cherry-pick to `main` is appropriate once the fix is verified.

## Release

Once merged, a 3.3.1 patch release on the 3.33-LTS line via the existing `release-prepare.yml` / `release-perform.yml` workflows would unblock downstream consumers without them needing the workaround.