### PR TITLE
chore(release): 3.3.1 (LTS line)

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,3 +1,3 @@
 release:
-  current-version: "3.3.0"
+  current-version: "3.3.1"
   next-version: "999-SNAPSHOT"


### PR DESCRIPTION
Patch release on the 3.33-LTS line. Includes the fix from #558 / #557: `DevServicesOpenSearchProcessor` is now loadable when `opensearch-testcontainers` is absent from the deployment classpath, and the testcontainers dep version is propagated to downstream consumers. Merging this PR triggers `release-prepare.yml` -> tag -> `release-perform.yml` (publish to Maven Central).