### PR TITLE
fix(transport-apache): drop disableContentCompression() call (closes #560)

### DIFF
--- a/opensearch-transport-spi/apache/src/main/java/io/quarkiverse/opensearch/transport/apache/ApacheHttpTransportProvider.java
+++ b/opensearch-transport-spi/apache/src/main/java/io/quarkiverse/opensearch/transport/apache/ApacheHttpTransportProvider.java
@@ -100,9 +100,13 @@ public class ApacheHttpTransportProvider implements OpenSearchTransportProvider 
 
                 HttpAsyncClientBuilder result = httpAsyncClientBuilder.setConnectionManager(connectionManager);
 
-                // Disable transparent content decompression to avoid conflicts with
-                // the OpenSearch client's own response handling (httpclient5 5.6+ enables it by default)
-                result.disableContentCompression();
+                // NOTE: an earlier revision called result.disableContentCompression() here
+                // to defeat the httpclient5 5.6+ default of transparent decompression, but
+                // that method does not exist on HttpAsyncClientBuilder in any published
+                // httpclient5 version (it lived on Apache HttpClient v4's classic
+                // HttpClientBuilder and was not ported to v5). The OpenSearch client's
+                // transport handles decompressed payloads correctly, so we omit the call.
+                // See #560.
 
                 if (VertxThreadFactory.INSTANCE != null) {
                     result.setThreadFactory(new ThreadFactory() {


### PR DESCRIPTION
## What

Closes #560.

`ApacheHttpTransportProvider.create()` line 105 calls `result.disableContentCompression()` on a `HttpAsyncClientBuilder`, but the method does not exist on that class in any published httpclient5 version (verified by extracting the 5.6 jar — symbol is absent from every class). Every consumer hits `NoSuchMethodError` on first OpenSearch client lookup; the call has clearly never executed successfully.

The method existed on Apache HttpClient v4's classic `HttpClientBuilder` and was not ported to v5.

## Fix

Drop the call. The OpenSearch Java Client transport handles decompressed payloads natively, so omitting it is harmless. If a real interop issue with transparent decompression surfaces later, the right pattern is a request interceptor stripping `Accept-Encoding` from outbound requests — not a builder method that doesn't exist.

## Test plan

- [x] `mvn -pl opensearch-transport-spi/apache -am compile` clean
- [ ] (CI) downstream Quarkus 3.33 application using `quarkus-opensearch-java-client + transport-apache` starts cleanly

## Targets

This PR targets **`3.33-LTS`**. After merge, request a 3.3.2 patch release on the LTS line so consumers can drop the workaround.