### PR TITLE
chore(release): 3.3.2

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,3 +1,3 @@
 release:
-  current-version: "3.3.1"
+  current-version: "3.3.2"
   next-version: "999-SNAPSHOT"


### PR DESCRIPTION
Patch on 3.33-LTS. Includes the fix from #561 / #560: removes the non-existent disableContentCompression() call on HttpAsyncClientBuilder that crashed every consumer at startup.