### PR TITLE
chore: add #560 regression marker, drop stale dependabot ignore

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,5 +11,3 @@ updates:
       interval: "daily"
     ignore:
       - dependency-name: "org.apache.maven.plugins:maven-compiler-plugin"
-      - dependency-name: "org.opensearch:opensearch-testcontainers"
-        versions: [">=4.0.0"]

--- a/opensearch-transport-spi/apache/src/main/java/io/quarkiverse/opensearch/transport/apache/ApacheHttpTransportProvider.java
+++ b/opensearch-transport-spi/apache/src/main/java/io/quarkiverse/opensearch/transport/apache/ApacheHttpTransportProvider.java
@@ -100,6 +100,10 @@ public class ApacheHttpTransportProvider implements OpenSearchTransportProvider 
 
                 HttpAsyncClientBuilder result = httpAsyncClientBuilder.setConnectionManager(connectionManager);
 
+                // Do not call result.disableContentCompression(): the method exists on httpclient4's
+                // classic HttpClientBuilder but not on httpclient5's HttpAsyncClientBuilder (see #560).
+                // The OpenSearch transport handles decompressed payloads, so the default is fine.
+
                 if (VertxThreadFactory.INSTANCE != null) {
                     result.setThreadFactory(new ThreadFactory() {
                         @Override


### PR DESCRIPTION
Prevents accidental reintroduction of disableContentCompression() (#560) and removes the opensearch-testcontainers >=4.0.0 ignore now that Quarkus 3.34 ships Testcontainers 2.x.