### PR TITLE
fix(devservices): processor loadable without testcontainers on classpath

### DIFF
--- a/opensearch-client-common/deployment/pom.xml
+++ b/opensearch-client-common/deployment/pom.xml
@@ -35,6 +35,10 @@
         <dependency>
             <groupId>org.opensearch</groupId>
             <artifactId>opensearch-testcontainers</artifactId>
+            <!-- Pin the version explicitly so the published deployment-artifact pom
+                 carries it, instead of relying on downstream consumers to walk the
+                 parent chain for ${opensearch-testcontainers.version}. See #557. -->
+            <version>${opensearch-testcontainers.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>junit</groupId>

--- a/opensearch-client-common/deployment/src/main/java/io/quarkiverse/opensearch/deployment/DevServicesOpenSearchProcessor.java
+++ b/opensearch-client-common/deployment/src/main/java/io/quarkiverse/opensearch/deployment/DevServicesOpenSearchProcessor.java
@@ -5,8 +5,6 @@ import java.util.*;
 import java.util.function.Supplier;
 
 import org.jboss.logging.Logger;
-import org.opensearch.testcontainers.OpenSearchContainer;
-import org.testcontainers.utility.DockerImageName;
 
 import io.quarkus.builder.BuildException;
 import io.quarkus.deployment.IsNormal;
@@ -156,26 +154,19 @@ public class DevServicesOpenSearchProcessor {
         Optional<ContainerAddress> maybeContainerAddress = openSearchContainerLocator.locateContainer(
                 config.serviceName(), config.shared(), launchMode.getLaunchMode());
 
-        Supplier<DevServicesResultBuildItem.RunningDevService> startContainer = () -> {
-            OpenSearchContainer container = new OpenSearchContainer(
-                    DockerImageName.parse(config.imageName())
-                            .asCompatibleSubstituteFor("opensearchproject/opensearch"));
-
-            if (config.serviceName() != null) {
-                container.withLabel(DEV_SERVICE_LABEL, config.serviceName());
-            }
-
-            config.port().ifPresent(port -> container.setPortBindings(List.of(port + ":" + port)));
-            timeout.ifPresent(container::withStartupTimeout);
-            container.addEnv("OPENSEARCH_JAVA_OPTS", config.javaOpts());
-
-            container.start();
-            return new DevServicesResultBuildItem.RunningDevService(
-                    OpenSearchDevServicesProcessor.FEATURE,
-                    container.getContainerId(),
-                    container::close,
-                    buildPropertiesMap(buildItemConfig, container.getHttpHostAddress()));
-        };
+        // Delegate the actual container creation to OpenSearchContainerStarter so that
+        // OpenSearchContainer / DockerImageName aren't referenced from this class's
+        // bytecode. Lets the processor load even when opensearch-testcontainers isn't
+        // on the deployment classpath (production builds without Dev Services). See #557.
+        Supplier<DevServicesResultBuildItem.RunningDevService> startContainer = () -> OpenSearchContainerStarter.start(
+                config.imageName(),
+                OpenSearchDevServicesProcessor.FEATURE,
+                DEV_SERVICE_LABEL,
+                Optional.ofNullable(config.serviceName()),
+                config.port(),
+                timeout,
+                config.javaOpts(),
+                buildItemConfig.hostsConfigProperties);
 
         return maybeContainerAddress
                 .map(addr -> new DevServicesResultBuildItem.RunningDevService(

--- a/opensearch-client-common/deployment/src/main/java/io/quarkiverse/opensearch/deployment/OpenSearchContainerStarter.java
+++ b/opensearch-client-common/deployment/src/main/java/io/quarkiverse/opensearch/deployment/OpenSearchContainerStarter.java
@@ -1,0 +1,69 @@
+package io.quarkiverse.opensearch.deployment;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.opensearch.testcontainers.OpenSearchContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import io.quarkus.deployment.builditem.DevServicesResultBuildItem;
+
+/**
+ * Lazily-loaded helper that creates and starts an {@link OpenSearchContainer}.
+ *
+ * <p>
+ * This class is the <strong>only</strong> place in the deployment module that references
+ * the OpenSearch testcontainers types. It is invoked from a {@code Supplier} inside
+ * {@link DevServicesOpenSearchProcessor}'s build step, so its bytecode is loaded only
+ * when Dev Services actually run (dev/test mode) — not when the deployment classpath is
+ * scanned at build time. Without this split, the JVM eagerly verifies the lambda's
+ * synthetic method on processor-class load, requiring
+ * {@code org.opensearch:opensearch-testcontainers} on the classpath even for production
+ * builds where Dev Services aren't used.
+ *
+ * <p>
+ * See <a href="https://github.com/quarkiverse/quarkus-opensearch/issues/557">issue #557</a>.
+ */
+final class OpenSearchContainerStarter {
+
+    private OpenSearchContainerStarter() {
+    }
+
+    static DevServicesResultBuildItem.RunningDevService start(
+            String imageName,
+            String featureName,
+            String containerLabel,
+            Optional<String> serviceName,
+            Optional<Integer> port,
+            Optional<Duration> startupTimeout,
+            String javaOpts,
+            Set<String> hostsConfigProperties) {
+
+        OpenSearchContainer container = new OpenSearchContainer(
+                DockerImageName.parse(imageName)
+                        .asCompatibleSubstituteFor("opensearchproject/opensearch"));
+
+        serviceName.ifPresent(name -> container.withLabel(containerLabel, name));
+        port.ifPresent(p -> container.setPortBindings(List.of(p + ":" + p)));
+        startupTimeout.ifPresent(container::withStartupTimeout);
+        container.addEnv("OPENSEARCH_JAVA_OPTS", javaOpts);
+
+        container.start();
+
+        Map<String, String> propertiesToSet = new HashMap<>();
+        String strippedHost = container.getHttpHostAddress().replaceFirst("^http://", "");
+        for (String property : hostsConfigProperties) {
+            propertiesToSet.put(property, strippedHost);
+        }
+
+        return new DevServicesResultBuildItem.RunningDevService(
+                featureName,
+                container.getContainerId(),
+                container::close,
+                propertiesToSet);
+    }
+}


### PR DESCRIPTION
Extract OpenSearchContainer usage into OpenSearchContainerStarter so the processor's bytecode no longer references testcontainers types directly. Lets the deployment processor load in production builds where the opensearch-testcontainers dependency isn't on the classpath.

Also declare the testcontainers version explicitly in the deployment pom so downstream consumers don't need to walk the parent chain.

Closes #557